### PR TITLE
feat: support all imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { start } = require('./viewer');
+const BundleAnalyzerPlugin = require('./BundleAnalyzerPlugin');
 
-module.exports = {
-  start,
-  BundleAnalyzerPlugin: require('./BundleAnalyzerPlugin')
-};
+BundleAnalyzerPlugin.start = start;
+BundleAnalyzerPlugin.BundleAnalyzerPlugin = BundleAnalyzerPlugin;
+module.exports = BundleAnalyzerPlugin;


### PR DESCRIPTION
```es6
import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
import * as BundleAnalyzerPlugin from 'webpack-bundle-analyzer'
import BundleAnalyzerPlugin from 'webpack-bundle-analyzer'

const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
```