### PR TITLE
setTimeout -> setImmediate

### DIFF
--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -47,10 +47,10 @@ class BundleAnalyzerPlugin {
 
       if (actions.length) {
         // Making analyzer logs to be after all webpack logs in the console
-        setTimeout(() => {
+        setImmediate(() => {
           console.log('');
           actions.forEach(action => action());
-        }, 200);
+        });
       }
     });
   }


### PR DESCRIPTION
If you run webpack not directly but through a wrapper (like grunt-webpack) then using `setTimeout` generates race conditions: sometimes grunt is killing webpack thinking that everything went good and bundle-analyze is not firing at all.

Changing that to `setImmediate` fixes the problem and still placing all the logs to the bottom