### PR TITLE
Fix case when bundleDir is '/'

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -87,7 +87,8 @@ function generateReport(bundleStats, opts) {
       let reportFilepath = reportFilename;
 
       if (!path.isAbsolute(reportFilepath)) {
-        reportFilepath = path.resolve(bundleDir || process.cwd(), reportFilepath);
+        const outputPath = bundleDir !== '/' && bundleDir || process.cwd();
+        reportFilepath = path.resolve(outputPath, reportFilepath);
       }
 
       mkdir.sync(path.dirname(reportFilepath));


### PR DESCRIPTION
For some reason in my repository, bundleDir is set to '/', causing the bundle analyzer plugin to try to write in '/report.html', therefore breaking because it was no permissions.