### PR TITLE
Only check children if assets is empty

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -21,7 +21,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
   } = opts || {};
 
   // Sometimes all the information is located in `children` array (e.g. problem in #10)
-  if (!_.isEmpty(bundleStats.children)) {
+  if (_.isEmpty(bundleStats.assets) && !_.isEmpty(bundleStats.children)) {
     bundleStats = bundleStats.children[0];
   }
 


### PR DESCRIPTION
So, I'm not really sure why there are stats files the are `children` only, but I'm finding the that my stats bundle has `assets` and `children`. I've a large setup including CSS Modules with ExtractTextPlugin. 

When using the CLI, I had this problem:

```
Could't find any javascript bundles in provided stats file
```

Summary of my stats file
```
{
  "errors": [],
  "warnings": [],
  "version": "1.13.2",
  "hash": "blah",
  "time": 1000,
  "publicPath": "/assets/",
  "assetsByChunkName": {
     .. omitted ..
  },
  "assets": [
    {
      "name": "vendor.js",
       .. omitted ..
    },
  ]
  "children": [
   "errors": [],
      "warnings": [],
      "publicPath": "/assets/",
      "assetsByChunkName": {},
      "assets": [],
      "chunks": [
        {
          "id": 0,
          "rendered": true,
          "initial": true,
          "entry": true,
          "extraAsync": false,
          "size": 2210,
          "names": [],
          "files": [
            "extract-text-webpack-plugin-output-filename"
          ],
          "hash": "blah",
          "parents": [],
          "origins": [
            {
              "moduleId": 0,
              "module": "somefile"
              "loc": "",
              "reasons": []
            }
          ]
        }
      ],
     .. omitted ..
  ]
}
```

The tests are passing. Happy to discuss further.
