### PR TITLE
Allow reports to be analyzed even with incomplete data

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -86,7 +86,7 @@ function getViewerData(bundleStats, bundleDir, opts) {
     asset.modules = _(bundleStats.modules)
       .filter(statModule => assetHasModule(statAsset, statModule))
       .each(statModule => {
-        if (parsedModuleSizes) {
+        if (parsedModuleSizes && parsedModuleSizes[statModule.id]) {
           statModule.parsedSize = parsedModuleSizes[statModule.id].raw;
           statModule.gzipSize = parsedModuleSizes[statModule.id].gzip;
         }


### PR DESCRIPTION
This partially addresses #29 by allowing the report to be generated at all in the first place. Now only the parts of the bundle that failed to be analyzed don't contain sizes for Gzip or parsed parts, but will still render successfully.

I suspect this will also help in debugging the issue further a lot.

![partial-info-but-still-works](https://cloud.githubusercontent.com/assets/482561/22513006/7fd2703c-e8a3-11e6-94cc-2d99590f752f.gif)
