### PR TITLE
Ability to set host address where HTTP server should listen

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ new BundleAnalyzerPlugin({
   // In `static` mode single HTML file with bundle report will be generated.
   // In `disabled` mode you can use this plugin to just generate Webpack Stats JSON file by setting `generateStatsFile` to `true`.
   analyzerMode: 'server',
+  // Host that will be used in `server` mode to start HTTP server.
+  analyzerHost: '127.0.0.1',
   // Port that will be used in `server` mode to start HTTP server.
   analyzerPort: 8888,
   // Path to bundle report file that will be generated in `static` mode.

--- a/src/BundleAnalyzerPlugin.js
+++ b/src/BundleAnalyzerPlugin.js
@@ -11,6 +11,7 @@ class BundleAnalyzerPlugin {
   constructor(opts) {
     this.opts = {
       analyzerMode: 'server',
+      analyzerHost: '127.0.0.1',
       analyzerPort: 8888,
       reportFilename: 'report.html',
       openAnalyzer: true,
@@ -80,6 +81,7 @@ class BundleAnalyzerPlugin {
   startAnalyzerServer(stats) {
     viewer.startServer(stats, {
       openBrowser: this.opts.openAnalyzer,
+      host: this.opts.analyzerHost,
       port: this.opts.analyzerPort,
       bundleDir: this.compiler.outputPath,
       logger: this.logger

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -23,6 +23,7 @@ module.exports = {
 function startServer(bundleStats, opts) {
   const {
     port = 8888,
+    host = '127.0.0.1',
     openBrowser = true,
     bundleDir = null,
     logger = new Logger()
@@ -48,8 +49,8 @@ function startServer(bundleStats, opts) {
     });
   });
 
-  return app.listen(port, () => {
-    const url = `http://localhost:${port}`;
+  return app.listen(port, host, () => {
+    const url = `http://${host}:${port}`;
 
     logger.info(
       `${bold('Webpack Bundle Analyzer')} is started at ${bold(url)}\n` +


### PR DESCRIPTION
Allows to set different bind host for Analyzer server.

Example use is when Analyzer is running inside Docker container with Virtualbox.
This setup requires to access running applications on different ip than localhost. So we need have way how make Analyzer server listen on `http://192.168.0.99:8888` or similar.