### PR TITLE
Don't add a module to a non-module object

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -160,6 +160,7 @@ class Folder extends Node {
       currentFolder = currentFolder.getChild(folderName) || currentFolder.addFolder(folderName);
     });
 
+    if (!currentModule.addModule) return;
     currentFolder.addModule(fileName, data);
   }
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -160,7 +160,7 @@ class Folder extends Node {
       currentFolder = currentFolder.getChild(folderName) || currentFolder.addFolder(folderName);
     });
 
-    if (!currentModule.addModule) return;
+    if (!currentFolder.addModule) return;
     currentFolder.addModule(fileName, data);
   }
 


### PR DESCRIPTION
Fixes #49  

Basically after some logging it looked like `currentFolder` in some situations ended up being a module, and modules don't have a `addModule` method.  This "fixed" it.

Not too familiar with the codebase so not sure if this could potentially break something