### PR TITLE
Add PowerShell specific stats.json generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ command:
 webpack --profile --json > stats.json
 ```
 
-If you're on Windows and using PowerShell, you can generate the stats file with this command to [avoid BOM issues]()https://github.com/th0r/webpack-bundle-analyzer/issues/47:
+If you're on Windows and using PowerShell, you can generate the stats file with this command to [avoid BOM issues](https://github.com/th0r/webpack-bundle-analyzer/issues/47):
 
 ```
 webpack --profile --json | Out-file 'stats.json' -Encoding OEM

--- a/README.md
+++ b/README.md
@@ -71,7 +71,17 @@ new BundleAnalyzerPlugin({
 You can also analyze already existing bundles if you have Webpack Stats JSON file.
 
 You can generate it using `BundleAnalyzerPlugin` with `generateStatsFile` option set to `true` or with this simple
-command: `webpack --profile --json > stats.json`
+command:
+
+```
+webpack --profile --json > stats.json
+```
+
+If you're on Windows and using PowerShell, you can generate the stats file with this command to [avoid BOM issues]()https://github.com/th0r/webpack-bundle-analyzer/issues/47:
+
+```
+webpack --profile --json | Out-file 'stats.json' -Encoding OEM
+```
 
 `webpack-bundle-analyzer --help` will show you all usage information.
 


### PR DESCRIPTION
To avoid issues like #47 in the future, it might be a good idea to document this PowerShell weirdness as described by @SukantGujar in https://github.com/th0r/webpack-bundle-analyzer/issues/47#issuecomment-279600901

What do you think?