### PR TITLE
Correctly advertise port when using a random one

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -59,7 +59,7 @@ async function startServer(bundleStats, opts) {
     server.listen(port, host, () => {
       resolve();
 
-      const url = `http://${host}:${port}`;
+      const url = `http://${host}:${server.address().port}`;
 
       logger.info(
         `${bold('Webpack Bundle Analyzer')} is started at ${bold(url)}\n` +


### PR DESCRIPTION
When using a port value of `0` (or if omitting the port argument) `httpServer` will assign a random port ([documentation](https://nodejs.org/api/http.html#http_server_listen_port_hostname_backlog_callback)).

Sadly `webpack-bundle-analyzer` will still advertise the port `0` and not the random one making the webserver impossible to find.

This patch simply change the url calculation by using `server.address().port` to retrieve the used port.