### PR TITLE
Allow webpack modules to be wrapped in arrow functions.

### DIFF
--- a/src/parseUtils.js
+++ b/src/parseUtils.js
@@ -144,7 +144,7 @@ function isArgumentArrayConcatContainingChunks(arg) {
 function isModuleWrapper(node) {
   return (
     // It's an anonymous function expression that wraps module
-    (node.type === 'FunctionExpression' && !node.id) ||
+    ((node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') && !node.id) ||
     // If `DedupePlugin` is used it can be an ID of duplicated module...
     isModuleId(node) ||
     // or an array of shape [<module_id>, ...args]

--- a/test/bundles/validBundleWithArrowFunction.js
+++ b/test/bundles/validBundleWithArrowFunction.js
@@ -1,0 +1,3 @@
+webpackJsonp([0],[(t,e,r)=>{
+  console.log("Hello world!");
+}]);

--- a/test/bundles/validBundleWithArrowFunction.modules.json
+++ b/test/bundles/validBundleWithArrowFunction.modules.json
@@ -1,0 +1,5 @@
+{
+  "modules": {
+    "0": "(t,e,r)=>{\n  console.log(\"Hello world!\");\n}"
+  }
+}


### PR DESCRIPTION
When using e.g. [uglifyjs](https://github.com/webpack-contrib/uglifyjs-webpack-plugin) with options ```{uglifyOptions: { ecma: 8 }}``` bundles with arrow functions are generated. This caused the analyser to always use ```stats``` over ```parsed``` and ```gzipped``` because it could not parse the bundles.

I don't know what's necessary to properly support this, but with this fix my project works nicely.